### PR TITLE
Setup PyPI and MCP Registry publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,11 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,25 +28,6 @@ jobs:
 
       - name: Build package
         run: uv build
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run tests
+        run: uv run pytest tests/ -v --tb=short --ignore=tests/test_integration.py
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/regenerate-site.yml
+++ b/.github/workflows/regenerate-site.yml
@@ -64,7 +64,7 @@ jobs:
             - **Logo:** Red-orange square (36px) with crown emoji 👑 + "Monarch Money MCP" text
             - **Navigation:** Tools, Installation, Credits (gray links, black on hover)
             - **Button:** "GitHub →" - black background, white text (red-orange on hover)
-            - Links to: https://github.com/jamiew/monarch-money-mcp
+            - Links to: https://github.com/jamiew/monarch-mcp
 
             ### Hero Section
             - **Title:** "Monarch Money MCP Server" (2.5rem, bold, black)
@@ -193,8 +193,8 @@ jobs:
             - White background, top border
             - Small gray text: "MIT License • GitHub • Issues"
             - Links:
-              - GitHub: https://github.com/jamiew/monarch-money-mcp
-              - Issues: https://github.com/jamiew/monarch-money-mcp/issues
+              - GitHub: https://github.com/jamiew/monarch-mcp
+              - Issues: https://github.com/jamiew/monarch-mcp/issues
 
             ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jamie Dubs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An [MCP](https://modelcontextprotocol.io/) server for [Monarch Money](https://ww
 
 Originally forked from [@colvint/monarch-money-mcp](https://github.com/colvint/monarch-money-mcp) but has diverged significantly with a full rewrite, many new features, and a modern FastMCP architecture.
 
+Built with the [MonarchMoney](https://github.com/hammem/monarchmoney) Python library by [@hammem](https://github.com/hammem) — a fantastic unofficial API for Monarch Money with full MFA support. We currently use the [community fork](https://github.com/bradleyseanf/monarchmoneycommunity) by [@bradleyseanf](https://github.com/bradleyseanf) which tracks the latest Monarch Money API changes.
+
 ## Features
 
 - **19 tools** covering accounts, transactions, budgets, cashflow, investments, categories, goals, net worth, recurring transactions, and more
@@ -165,4 +167,3 @@ uv run scripts/eval_session.py analyze            # analyze new entries
 
 This project started as a fork of [colvint/monarch-money-mcp](https://github.com/colvint/monarch-money-mcp) by [@colvint](https://github.com/colvint). Thanks for the original implementation!
 
-Built with the [MonarchMoney](https://github.com/hammem/monarchmoney) Python library by [@hammem](https://github.com/hammem) — a fantastic unofficial API for Monarch Money with full MFA support. We currently use the [community fork](https://github.com/bradleyseanf/monarchmoneycommunity) by [@bradleyseanf](https://github.com/bradleyseanf) which tracks the latest Monarch Money API changes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- mcp-name: io.github.jamiew/monarch-money-mcp -->
+<!-- mcp-name: io.github.jamiew/monarch-mcp -->
 # Monarch Money MCP Server
 
 An [MCP](https://modelcontextprotocol.io/) server for [Monarch Money](https://www.monarchmoney.com/) — gives AI assistants like Claude access to your financial accounts, transactions, budgets, and more.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.jamiew/monarch-money-mcp -->
 # Monarch Money MCP Server
 
 An [MCP](https://modelcontextprotocol.io/) server for [Monarch Money](https://www.monarchmoney.com/) — gives AI assistants like Claude access to your financial accounts, transactions, budgets, and more.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,31 @@
 [project]
 name = "monarch-money-mcp"
 version = "0.3.0"
-description = "MCP server for MonarchMoney financial data access"
+description = "MCP server for Monarch Money personal finance"
 readme = "README.md"
 requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Jamie Dubs", email = "jamie@jamiedubs.com" },
+]
+keywords = [
+    "mcp",
+    "model-context-protocol",
+    "monarch-money",
+    "finance",
+    "budgeting",
+    "personal-finance",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Office/Business :: Financial",
+]
 dependencies = [
     "mcp[cli]>=1.26.0,<2",
     "monarchmoneycommunity",
@@ -12,8 +34,28 @@ dependencies = [
     "structlog>=25.5.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/jamiew/monarch-mcp"
+Repository = "https://github.com/jamiew/monarch-mcp"
+Issues = "https://github.com/jamiew/monarch-mcp/issues"
+
 [project.scripts]
 monarch-money-mcp = "server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["server.py"]
+
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "server.py",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "monarch-money-mcp"
+name = "monarch-mcp-jamiew"
 version = "0.3.0"
 description = "MCP server for Monarch Money personal finance"
 readme = "README.md"
@@ -40,7 +40,7 @@ Repository = "https://github.com/jamiew/monarch-mcp"
 Issues = "https://github.com/jamiew/monarch-mcp/issues"
 
 [project.scripts]
-monarch-money-mcp = "server:main"
+monarch-mcp-jamiew = "server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.jamiew/monarch-money-mcp",
-  "title": "Monarch Money MCP Server",
-  "description": "Access Monarch Money financial data — accounts, transactions, budgets, and more",
+  "name": "io.github.jamiew/monarch-mcp",
+  "title": "Monarch MCP Server",
+  "description": "Access Monarch financial data — accounts, transactions, budgets, and more",
   "version": "0.3.0",
   "repository": {
     "url": "https://github.com/jamiew/monarch-mcp",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jamiew/monarch-money-mcp",
+  "title": "Monarch Money MCP Server",
+  "description": "Access Monarch Money financial data — accounts, transactions, budgets, and more",
+  "version": "0.3.0",
+  "repository": {
+    "url": "https://github.com/jamiew/monarch-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "monarch-money-mcp",
+      "version": "0.3.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "MONARCH_EMAIL",
+          "description": "Your Monarch Money account email",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "MONARCH_PASSWORD",
+          "description": "Your Monarch Money account password",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "MONARCH_MFA_SECRET",
+          "description": "Your TOTP secret key for 2FA",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "MONARCH_FORCE_LOGIN",
+          "description": "Set to 'true' to bypass session cache",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
+  "tools": [
+    { "name": "get_accounts", "description": "List all financial accounts with balances" },
+    { "name": "get_transactions", "description": "Get transactions with date/account/category filtering" },
+    { "name": "search_transactions", "description": "Search transactions by merchant name or keyword" },
+    { "name": "get_budgets", "description": "Get budget data and spending limits" },
+    { "name": "get_cashflow", "description": "Get income and expense cashflow data" },
+    { "name": "get_transaction_categories", "description": "List transaction categories" },
+    { "name": "create_transaction", "description": "Create a manual transaction" },
+    { "name": "update_transaction", "description": "Update an existing transaction" },
+    { "name": "update_transactions_bulk", "description": "Update multiple transactions in parallel" },
+    { "name": "get_account_holdings", "description": "Get investment holdings for an account" },
+    { "name": "get_account_history", "description": "Get historical balance data for an account" },
+    { "name": "get_institutions", "description": "List connected financial institutions" },
+    { "name": "get_recurring_transactions", "description": "Get recurring/subscription transactions" },
+    { "name": "set_budget_amount", "description": "Set budget amount for a category" },
+    { "name": "create_manual_account", "description": "Create a manual tracking account" },
+    { "name": "refresh_accounts", "description": "Trigger refresh of account data" },
+    { "name": "get_spending_summary", "description": "Get spending summary by category/account/month" },
+    { "name": "get_complete_financial_overview", "description": "Get comprehensive financial snapshot in one call" },
+    { "name": "analyze_spending_patterns", "description": "Analyze spending trends with optional forecasting" }
+  ],
+  "securityConsiderations": "Monarch Money does not provide OAuth or official API access. This server requires your actual account credentials (email, password, MFA secret) which have full access to view and modify your financial data. Use with appropriate caution."
+}

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "pypi",
-      "identifier": "monarch-money-mcp",
+      "identifier": "monarch-mcp-jamiew",
       "version": "0.3.0",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -898,8 +898,8 @@ wheels = [
 
 [[package]]
 name = "monarch-money-mcp"
-version = "0.2.0"
-source = { virtual = "." }
+version = "0.3.0"
+source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "monarchmoneycommunity" },

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ wheels = [
 ]
 
 [[package]]
-name = "monarch-money-mcp"
+name = "monarch-mcp-jamiew"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
Adds everything needed to publish to PyPI and the official MCP Registry.

- MIT LICENSE file
- hatchling build system (produces a clean ~24KB wheel with just server.py)
- PyPI metadata in pyproject.toml (authors, classifiers, keywords, URLs)
- server.json manifest for MCP Registry (2025-12-11 schema, all 19 tools)
- GitHub Actions workflow that tests + publishes to PyPI on release
- mcp-name verification tag in README for registry linking

## After merging

### PyPI setup (one-time)
1. Go to https://pypi.org/manage/account/publishing/
2. Add a new "pending publisher": owner=`jamiew`, repo=`monarch-mcp`, workflow=`publish.yml`, environment=`pypi`
3. Create a `pypi` environment in GitHub repo Settings → Environments
4. Create a new GitHub release to trigger the publish

### MCP Registry (one-time, after PyPI publish)
```bash
brew install mcp-publisher          # or curl install
mcp-publisher login github          # OAuth device flow
mcp-publisher publish --dry-run     # validate first
mcp-publisher publish               # submit to registry
```