### PR TITLE
feat: add split transaction support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,10 @@ refactor: split server.py into modular components (auth, tools, models)
 - Structured logging with `structlog` for debugging
 - Environment variables: `MONARCH_EMAIL`, `MONARCH_PASSWORD`, `MONARCH_MFA_SECRET`
 
-**Complete Monarch Money API Coverage (22 Tools)**
+**Complete Monarch Money API Coverage (24 Tools)**
 - **Core**: `get_accounts`, `get_transactions`, `get_budgets`, `get_cashflow`
 - **Categories**: `get_transaction_categories`
-- **Transactions**: `create_transaction`, `update_transaction`, `update_transactions_bulk`, `search_transactions`
+- **Transactions**: `create_transaction`, `update_transaction`, `update_transactions_bulk`, `search_transactions`, `get_transaction_splits`, `split_transaction`
 - **Investments**: `get_account_holdings`, `get_account_history`
 - **Banking**: `get_institutions`, `refresh_accounts`
 - **Planning**: `get_recurring_transactions`, `set_budget_amount`
@@ -400,7 +400,7 @@ Server runs as MCP server configured in `.mcp.json` with:
 5. **Phase 5 (Intelligence)**: ML features, advanced analytics, financial insights
 6. **Phase 6 (Ecosystem)**: MCP extensions, developer tools, architectural improvements
 
-**Current Status** (Updated October 2025): Production-ready with 70 passing tests, 22 intelligent tools, comprehensive analytics, robust error handling, and enhanced reliability. Recent features: `update_transactions_bulk()` for parallel batch updates, `search_transactions` tool for efficient context-aware search, detailed tool call debugging with result size tracking. Recent critical fixes completed: authentication retry bug (stale client after re-auth), date serialization, broken pipe handling, dependency updates, and enhanced date parsing. Server is stable and ready for real-world usage with excellent user experience for date filtering, bulk operations, and error recovery.
+**Current Status** (Updated March 2026): Production-ready with 24 intelligent tools, comprehensive analytics, robust error handling, and enhanced reliability. Recent additions: `get_transaction_splits` and `split_transaction` tools for full split transaction support (read and create/update/delete splits). Previous features: `update_transactions_bulk()` for parallel batch updates, `search_transactions` tool for efficient context-aware search. Server is stable and ready for real-world usage with excellent user experience for date filtering, bulk operations, split transactions, and error recovery.
 
 ## Documentation References
 

--- a/server.py
+++ b/server.py
@@ -1608,6 +1608,157 @@ async def update_transactions_bulk(updates: str) -> str:
 
 @mcp.tool(annotations=READONLY)
 @track_usage
+async def get_transaction_splits(transaction_id: str) -> str:
+    """Get split transaction details for a transaction.
+
+    Returns the parent transaction info and any splits associated with it.
+    If the transaction has no splits, splitTransactions will be an empty array.
+
+    Args:
+        transaction_id: ID of the parent transaction to retrieve splits for
+
+    Returns:
+        JSON string with parent transaction (id, amount, category, merchant) and
+        splitTransactions array. Each split has: id, merchant, category, amount, notes.
+
+    Example response structure:
+        {
+          "getTransaction": {
+            "id": "txn_123",
+            "amount": -50.00,
+            "category": {"id": "cat_001", "name": "Groceries"},
+            "merchant": {"id": "m_001", "name": "Supermarket"},
+            "splitTransactions": [
+              {"id": "split_1", "merchant": {"name": "Corner Deli"}, "category": {"id": "cat_002", "name": "Dining"}, "amount": -30.00, "notes": ""},
+              {"id": "split_2", "merchant": {"name": "Bakery"}, "category": {"id": "cat_003", "name": "Groceries"}, "amount": -20.00, "notes": "bread"}
+            ]
+          }
+        }
+    """
+    await ensure_authenticated()
+
+    try:
+        result = await asyncio.wait_for(
+            api_call_with_retry("get_transaction_splits", transaction_id=transaction_id),
+            timeout=30.0,
+        )
+        result = convert_dates_to_strings(result)
+        return json.dumps(result, indent=2)
+    except asyncio.TimeoutError as e:
+        log.error("get_transaction_splits_timeout", transaction_id=transaction_id)
+        raise ValueError("Request timed out after 30 seconds. Please try again.") from e
+    except Exception as e:
+        log.error("get_transaction_splits_failed", transaction_id=transaction_id, error=str(e))
+        raise
+
+
+@mcp.tool(annotations=WRITE_IDEMPOTENT)
+@track_usage
+async def split_transaction(transaction_id: str, split_data: str) -> str:
+    """Split a transaction into multiple parts with different merchants and categories.
+
+    Replaces ALL existing splits for the transaction with the provided splits.
+    Pass an empty array to remove all splits.
+
+    Args:
+        transaction_id: ID of the parent transaction to split
+        split_data: JSON string containing a list of split objects. Each split requires:
+            - merchantName (str): Merchant name for this split portion
+            - amount (float): Amount for this split (must match sign of parent transaction)
+            - categoryId (str): Category ID to assign to this split
+            - notes (str, optional): Notes/memo for this split
+
+            The sum of all split amounts must exactly equal the parent transaction amount.
+            Pass "[]" to remove all splits from the transaction.
+
+    Returns:
+        JSON string with the updated transaction including hasSplitTransactions flag
+        and the new splitTransactions array.
+
+    Examples:
+        Split a -50.00 dining charge two ways:
+            split_data = '[
+                {"merchantName": "Corner Deli", "amount": -30.00, "categoryId": "cat_001"},
+                {"merchantName": "Bakery", "amount": -20.00, "categoryId": "cat_002", "notes": "bread"}
+            ]'
+
+        Remove all splits from a transaction:
+            split_data = "[]"
+
+    Notes:
+        - This operation is idempotent: calling with the same split_data produces the same result
+        - Existing splits are fully replaced, not merged
+        - Use get_transaction_categories to find valid category IDs
+        - Use get_transaction_splits to view current splits before modifying
+    """
+    await ensure_authenticated()
+
+    try:
+        # Parse the JSON string
+        try:
+            splits_list: Any = json.loads(split_data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in split_data parameter: {e}") from e
+
+        if not isinstance(splits_list, list):
+            raise ValueError("split_data must be a JSON array (list), not an object or scalar")
+
+        # Empty list = delete all splits
+        if len(splits_list) == 0:
+            result = await asyncio.wait_for(
+                api_call_with_retry("update_transaction_splits", transaction_id=transaction_id, split_data=[]),
+                timeout=30.0,
+            )
+            result = convert_dates_to_strings(result)
+            log.info("split_transaction_cleared", transaction_id=transaction_id)
+            return json.dumps(result, indent=2)
+
+        # Validate required fields on each split
+        required_fields = {"merchantName", "amount", "categoryId"}
+        for i, split in enumerate(splits_list):
+            missing = required_fields - set(split.keys())
+            if missing:
+                raise ValueError(f"Split at index {i} is missing required fields: {sorted(missing)}")
+            if not isinstance(split["amount"], (int, float)):
+                raise ValueError(f"Split at index {i} has invalid amount: must be a number")
+
+        # Validate that split amounts sum to the parent transaction amount
+        parent_result = await asyncio.wait_for(
+            api_call_with_retry("get_transaction_splits", transaction_id=transaction_id),
+            timeout=30.0,
+        )
+        parent_amount: float | None = parent_result.get("getTransaction", {}).get("amount", None)
+        if parent_amount is None:
+            raise ValueError(f"Could not retrieve parent transaction amount for transaction {transaction_id}")
+
+        split_sum = sum(float(s["amount"]) for s in splits_list)
+        if abs(parent_amount - split_sum) > 0.01:
+            raise ValueError(
+                f"Split amounts sum to {split_sum:.2f} but parent transaction amount is {parent_amount:.2f}. "
+                "The sum of all split amounts must equal the parent transaction amount."
+            )
+
+        log.info("split_transaction", transaction_id=transaction_id, split_count=len(splits_list))
+
+        result = await asyncio.wait_for(
+            api_call_with_retry("update_transaction_splits", transaction_id=transaction_id, split_data=splits_list),
+            timeout=30.0,
+        )
+        result = convert_dates_to_strings(result)
+        return json.dumps(result, indent=2)
+
+    except asyncio.TimeoutError as e:
+        log.error("split_transaction_timeout", transaction_id=transaction_id)
+        raise ValueError("Request timed out after 30 seconds. Please try again.") from e
+    except ValueError:
+        raise
+    except Exception as e:
+        log.error("split_transaction_failed", transaction_id=transaction_id, error=str(e))
+        raise
+
+
+@mcp.tool(annotations=READONLY)
+@track_usage
 async def get_account_holdings() -> str:
     """Get investment portfolio data from brokerage accounts."""
     await ensure_authenticated()

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -1,0 +1,282 @@
+"""Tests for split transaction functionality."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+PARENT_TRANSACTION = {
+    "getTransaction": {
+        "id": "txn_parent_123",
+        "amount": -50.00,
+        "category": {"id": "cat_001", "name": "Groceries", "__typename": "Category"},
+        "merchant": {"id": "m_001", "name": "Supermarket", "__typename": "Merchant"},
+        "splitTransactions": [
+            {
+                "id": "split_1",
+                "merchant": {"id": "m_002", "name": "Corner Deli", "__typename": "Merchant"},
+                "category": {"id": "cat_002", "name": "Dining", "__typename": "Category"},
+                "amount": -30.00,
+                "notes": "",
+                "__typename": "Transaction",
+            },
+            {
+                "id": "split_2",
+                "merchant": {"id": "m_003", "name": "Bakery", "__typename": "Merchant"},
+                "category": {"id": "cat_001", "name": "Groceries", "__typename": "Category"},
+                "amount": -20.00,
+                "notes": "bread",
+                "__typename": "Transaction",
+            },
+        ],
+        "__typename": "Transaction",
+    }
+}
+
+PARENT_NO_SPLITS = {
+    "getTransaction": {
+        "id": "txn_parent_456",
+        "amount": -75.00,
+        "category": {"id": "cat_003", "name": "Shopping", "__typename": "Category"},
+        "merchant": {"id": "m_004", "name": "Department Store", "__typename": "Merchant"},
+        "splitTransactions": [],
+        "__typename": "Transaction",
+    }
+}
+
+UPDATE_RESULT = {
+    "updateTransactionSplit": {
+        "errors": None,
+        "transaction": {
+            "id": "txn_parent_123",
+            "hasSplitTransactions": True,
+            "splitTransactions": [
+                {
+                    "id": "split_new_1",
+                    "merchant": {"id": "m_002", "name": "Corner Deli", "__typename": "Merchant"},
+                    "category": {"id": "cat_002", "name": "Dining", "__typename": "Category"},
+                    "amount": -30.00,
+                    "notes": "",
+                    "__typename": "Transaction",
+                },
+                {
+                    "id": "split_new_2",
+                    "merchant": {"id": "m_003", "name": "Bakery", "__typename": "Merchant"},
+                    "category": {"id": "cat_001", "name": "Groceries", "__typename": "Category"},
+                    "amount": -20.00,
+                    "notes": "bread",
+                    "__typename": "Transaction",
+                },
+            ],
+            "__typename": "Transaction",
+        },
+        "__typename": "UpdateTransactionSplitPayload",
+    }
+}
+
+
+class TestGetTransactionSplits:
+    """Tests for the get_transaction_splits tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_splits_success(self):
+        """Test successful retrieval of transaction splits."""
+        from server import get_transaction_splits
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(return_value=PARENT_TRANSACTION)
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            result_str = await get_transaction_splits("txn_parent_123")
+            result = json.loads(result_str)
+
+            assert result["getTransaction"]["id"] == "txn_parent_123"
+            assert result["getTransaction"]["amount"] == -50.00
+            assert len(result["getTransaction"]["splitTransactions"]) == 2
+            assert result["getTransaction"]["splitTransactions"][0]["amount"] == -30.00
+            assert result["getTransaction"]["splitTransactions"][1]["notes"] == "bread"
+
+    @pytest.mark.asyncio
+    async def test_get_splits_no_splits(self):
+        """Test retrieval of a transaction that has no splits."""
+        from server import get_transaction_splits
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(return_value=PARENT_NO_SPLITS)
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            result_str = await get_transaction_splits("txn_parent_456")
+            result = json.loads(result_str)
+
+            assert result["getTransaction"]["id"] == "txn_parent_456"
+            assert result["getTransaction"]["splitTransactions"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_splits_api_error(self):
+        """Test error propagation on API failure."""
+        from server import get_transaction_splits
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(side_effect=Exception("Transaction not found"))
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            with pytest.raises(Exception, match="Transaction not found"):
+                await get_transaction_splits("txn_nonexistent")
+
+
+class TestSplitTransaction:
+    """Tests for the split_transaction tool."""
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_success(self):
+        """Test successful split of a transaction."""
+        from server import split_transaction
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(return_value=PARENT_TRANSACTION)
+        mock_client.update_transaction_splits = AsyncMock(return_value=UPDATE_RESULT)
+
+        split_data = json.dumps(
+            [
+                {"merchantName": "Corner Deli", "amount": -30.00, "categoryId": "cat_002"},
+                {"merchantName": "Bakery", "amount": -20.00, "categoryId": "cat_001", "notes": "bread"},
+            ]
+        )
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            result_str = await split_transaction("txn_parent_123", split_data)
+            result = json.loads(result_str)
+
+            assert result["updateTransactionSplit"]["transaction"]["hasSplitTransactions"] is True
+            assert len(result["updateTransactionSplit"]["transaction"]["splitTransactions"]) == 2
+
+            # Verify the API was called with correct arguments
+            mock_client.update_transaction_splits.assert_called_once()
+            call_kwargs = mock_client.update_transaction_splits.call_args[1]
+            assert call_kwargs["transaction_id"] == "txn_parent_123"
+            assert len(call_kwargs["split_data"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_delete_splits(self):
+        """Test removing all splits by passing an empty array."""
+        from server import split_transaction
+
+        delete_result = {
+            "updateTransactionSplit": {
+                "errors": None,
+                "transaction": {"id": "txn_parent_123", "hasSplitTransactions": False, "splitTransactions": []},
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.update_transaction_splits = AsyncMock(return_value=delete_result)
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            result_str = await split_transaction("txn_parent_123", "[]")
+            result = json.loads(result_str)
+
+            assert result["updateTransactionSplit"]["transaction"]["hasSplitTransactions"] is False
+
+            # Verify called with empty list
+            call_kwargs = mock_client.update_transaction_splits.call_args[1]
+            assert call_kwargs["split_data"] == []
+            # Should NOT call get_transaction_splits (no validation needed for delete)
+            mock_client.get_transaction_splits.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_invalid_json(self):
+        """Test error handling for invalid JSON input."""
+        from server import split_transaction
+
+        with patch("server.ensure_authenticated", new_callable=AsyncMock):
+            with pytest.raises(ValueError, match="Invalid JSON"):
+                await split_transaction("txn_123", "not valid json {")
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_not_array(self):
+        """Test error handling when split_data is a JSON object instead of array."""
+        from server import split_transaction
+
+        with patch("server.ensure_authenticated", new_callable=AsyncMock):
+            with pytest.raises(ValueError, match="must be a JSON array"):
+                await split_transaction("txn_123", '{"merchantName": "Deli", "amount": -50.00}')
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_amount_mismatch(self):
+        """Test error when split amounts don't sum to parent transaction amount."""
+        from server import split_transaction
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(return_value=PARENT_TRANSACTION)  # parent = -50.00
+
+        split_data = json.dumps(
+            [
+                {"merchantName": "Corner Deli", "amount": -30.00, "categoryId": "cat_002"},
+                {"merchantName": "Bakery", "amount": -15.00, "categoryId": "cat_001"},  # sum = -45.00, not -50.00
+            ]
+        )
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            with pytest.raises(ValueError, match="Split amounts sum to"):
+                await split_transaction("txn_parent_123", split_data)
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_amount_rounding_tolerance(self):
+        """Test that amounts within 0.01 floating-point tolerance are accepted."""
+        from server import split_transaction
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(return_value=PARENT_TRANSACTION)  # parent = -50.00
+        mock_client.update_transaction_splits = AsyncMock(return_value=UPDATE_RESULT)
+
+        # Amounts that sum to -49.999 (within 0.01 tolerance of -50.00)
+        split_data = json.dumps(
+            [
+                {"merchantName": "Corner Deli", "amount": -29.999, "categoryId": "cat_002"},
+                {"merchantName": "Bakery", "amount": -20.000, "categoryId": "cat_001"},
+            ]
+        )
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            result_str = await split_transaction("txn_parent_123", split_data)
+            result = json.loads(result_str)
+
+            assert result["updateTransactionSplit"]["transaction"]["hasSplitTransactions"] is True
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_missing_required_fields(self):
+        """Test error when a split is missing required fields."""
+        from server import split_transaction
+
+        with patch("server.ensure_authenticated", new_callable=AsyncMock):
+            # Missing categoryId
+            split_data = json.dumps(
+                [
+                    {"merchantName": "Corner Deli", "amount": -50.00},
+                ]
+            )
+            with pytest.raises(ValueError, match="missing required fields"):
+                await split_transaction("txn_123", split_data)
+
+    @pytest.mark.asyncio
+    async def test_split_transaction_with_notes(self):
+        """Test that optional notes field passes through correctly."""
+        from server import split_transaction
+
+        mock_client = MagicMock()
+        mock_client.get_transaction_splits = AsyncMock(return_value=PARENT_TRANSACTION)
+        mock_client.update_transaction_splits = AsyncMock(return_value=UPDATE_RESULT)
+
+        split_data = json.dumps(
+            [
+                {"merchantName": "Corner Deli", "amount": -30.00, "categoryId": "cat_002", "notes": "lunch"},
+                {"merchantName": "Bakery", "amount": -20.00, "categoryId": "cat_001"},
+            ]
+        )
+
+        with patch("server.mm_client", mock_client), patch("server.ensure_authenticated", new_callable=AsyncMock):
+            await split_transaction("txn_parent_123", split_data)
+
+            call_kwargs = mock_client.update_transaction_splits.call_args[1]
+            assert call_kwargs["split_data"][0]["notes"] == "lunch"
+            assert "notes" not in call_kwargs["split_data"][1]  # notes not added when not provided


### PR DESCRIPTION
## Summary
- Add `get_transaction_splits` tool to read splits for a parent transaction
- Add `split_transaction` tool to create/update/delete splits with full validation (amount sum check, required field validation, idempotent replace)
- Add comprehensive tests for both tools

## Details
These two new tools complete split transaction support in the MCP server:

- **`get_transaction_splits(transaction_id)`** — Returns the parent transaction info and any associated splits
- **`split_transaction(transaction_id, split_data)`** — Replaces all splits on a transaction with the provided list. Validates that split amounts sum to the parent amount, checks required fields, and supports clearing splits with an empty array.

## Test plan
- [ ] `uv run pytest tests/test_splits.py -v` — new split transaction tests pass
- [ ] `uv run pytest tests/ -v` — all existing tests still pass
- [ ] `uv run mypy server.py` — type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)