### PR TITLE
Add interactive auth (elicitation + cookies) and keyring-backed sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ Use generic, obviously-fake examples instead: "Main Credit Card", "Corner Deli",
 - `MONARCH_FORCE_LOGIN=true uv run python server.py` - Force fresh login (if session expires)
 
 ### Debugging Startup Issues (Updated July 2025)
-- **Session expired**: Delete `~/.monarch-mcp/session.pickle` or set `MONARCH_FORCE_LOGIN=true`
+- **Session expired**: Call `monarch_logout`, delete `~/.monarch-mcp/session.pickle`, or set `MONARCH_FORCE_LOGIN=true`
+- **CAPTCHA / MFA / emailed one-time code blocks login**: Non-interactive login can't solve these. Run `uv run scripts/login_setup.py`, or call the `monarch_login`/`monarch_login_with_cookies` MCP tools
 - **JSON parse errors**: Fixed - all stdout output suppressed with `contextlib.redirect_stdout()`
 - **MCP protocol compliance**: All logging/warnings redirected to stderr, third-party lib output suppressed
 - **AsyncIO errors**: Fixed - uses `run_stdio_async()` in async context
@@ -166,12 +167,13 @@ refactor: split server.py into modular components (auth, tools, models)
 - Automatic capability negotiation and tool discovery
 
 **Secure Authentication & Session Management**
-- Sessions stored in `~/.monarch-mcp/` directory (override via `MONARCH_SESSION_DIR`) with 0700 permissions  
-- Proper `RequireMFAException` handling
+- Non-interactive login via `MONARCH_EMAIL`/`MONARCH_PASSWORD`/`MONARCH_MFA_SECRET` env vars remains the primary path (`initialize_client()`), handling TOTP MFA via `mfa_secret_key`.
+- Monarch's login can also sit behind a Cloudflare CAPTCHA (`CaptchaRequiredException`) or require an emailed one-time code (raised as `RequireMFAException` by our fork, indistinguishable from TOTP MFA at that layer) — neither satisfiable headlessly. `initialize_client()` surfaces an actionable error for both pointing at the interactive paths below, instead of a generic failure.
+- **Interactive escape hatch**: `monarch_login` / `monarch_login_with_cookies` MCP tools (using `Context.elicit` — credentials flow client-UI → server, never through tool arguments or the model) and `scripts/login_setup.py` (terminal script for repo clones: browser-cookie / password+MFA / token-paste paths). `monarch_logout` clears the session; `check_auth_status` reports whether one is active or saved.
+- **Session storage**: keyring-first (`save_session_secure()`/`load_session_secure()`/`clear_session_secure()` in `server.py`), via the OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) when a real backend is available — probed with a set/get/delete round-trip (`_keyring_available()`), since headless environments often have the `keyring` package but no working backend. Falls back to a 0600 file under `~/.monarch-mcp/` (override via `MONARCH_SESSION_DIR`) otherwise. The blob itself is produced via the monarchmoney client's own `save_session()`/`load_session()` (off a scratch temp file), so it stores whatever the library's session format is (token and/or cookies), not a bespoke format.
 - Structured logging with `structlog` for debugging
-- Environment variables: `MONARCH_EMAIL`, `MONARCH_PASSWORD`, `MONARCH_MFA_SECRET`
 
-**Complete Monarch Money API Coverage (21 Tools)**
+**Complete Monarch Money API Coverage (25 Tools)**
 - **Core**: `get_accounts`, `get_transactions`, `get_budgets`, `get_cashflow`
 - **Categories**: `get_transaction_categories`
 - **Transactions**: `create_transaction`, `update_transaction`, `update_transactions_bulk`, `search_transactions`
@@ -182,6 +184,7 @@ refactor: split server.py into modular components (auth, tools, models)
 - **Manual**: `create_manual_account`
 - **Batch Operations**: `get_spending_summary`, `update_transactions_bulk`
 - **Intelligent Analysis**: `get_complete_financial_overview`, `analyze_spending_patterns`
+- **Authentication**: `monarch_login`, `monarch_login_with_cookies`, `monarch_logout`, `check_auth_status`
 
 Also exposes 5 MCP resources (3 static lists + 2 parameterized templates: `accounts://{account_id}/holdings|history`) and 4 prompt templates.
 
@@ -238,9 +241,10 @@ Published to PyPI as `monarch-mcp-jamiew` and to the MCP Registry as `io.github.
 
 ### Session Management
 
-- Session files stored in `~/.monarch-mcp/` directory (created automatically; override via `MONARCH_SESSION_DIR`)
+- Sessions save to the OS keyring first, falling back to a 0600 file under `~/.monarch-mcp/` (created automatically; override via `MONARCH_SESSION_DIR`) when no keyring backend is available
 - Session invalidation handled gracefully with automatic re-authentication
 - Use `MONARCH_FORCE_LOGIN=true` to bypass session cache for debugging
+- When non-interactive login can't complete (CAPTCHA, MFA/email-OTP without `MONARCH_MFA_SECRET`), use `scripts/login_setup.py` or the `monarch_login`/`monarch_login_with_cookies` MCP tools to establish a session once; every tool call reuses it afterward
 - Sessions follow Monarch Money API session management patterns
 
 ## Status & Achievements
@@ -254,14 +258,14 @@ Published to PyPI as `monarch-mcp-jamiew` and to the MCP Registry as `io.github.
 - **✅ Structured Logging**: Context-rich logs with `structlog`
 - **✅ Complete API Coverage**: All 14 Monarch Money API methods as tools
 
-#### Quality Metrics (Updated May 2026)
-- **206 passing tests** with comprehensive coverage including analytics, search, bulk operations, splits, structured output, completions, resource templates, and progress
-- **21 tools** (all returning typed Pydantic models / structured output), 3 static resources + 2 resource templates, 4 prompts
+#### Quality Metrics (Updated August 2026)
+- **227 passing tests** with comprehensive coverage including analytics, search, bulk operations, splits, structured output, completions, resource templates, progress, and interactive/keyring authentication
+- **25 tools** (all returning typed Pydantic models / structured output), 3 static resources + 2 resource templates, 4 prompts
 - **MyPy clean** under the repo's strict config (no `Any` at non-boundaries, no `as`)
 - **Security**: Proper session handling and MFA support
 - **Modern stack**: FastMCP 1.12.2, Pydantic, structlog, pytest
 - **Usage analytics**: Real-time performance tracking and optimization suggestions
-- **Codebase**: 1,447 lines in server.py, 7 test files with comprehensive coverage
+- **Codebase**: ~2,900 lines in server.py, plus `scripts/login_setup.py` for interactive terminal auth; 19 test files with comprehensive coverage
 
 ### ✅ ADVANCED FEATURES (Recently Completed)
 
@@ -400,7 +404,7 @@ Published to PyPI as `monarch-mcp-jamiew` and to the MCP Registry as `io.github.
 5. **Phase 5 (Intelligence)**: ML features, advanced analytics, financial insights
 6. **Phase 6 (Ecosystem)**: MCP extensions, developer tools, architectural improvements
 
-**Current Status** (Updated June 2026): Production-ready with 206 passing tests, 21 intelligent tools (including transaction splitting via `get_transaction_splits` / `update_transaction_splits`), comprehensive analytics, robust error handling, and enhanced reliability. Recent MCP modernization: every tool returns structured output (outputSchema + structured content with a text fallback), tools/resources/prompts carry human-friendly `title`s, parameterized resource templates (`accounts://{account_id}/holdings|history`), argument completions for prompts/templates, and Context-based progress reporting on the batch tools. Earlier features: `update_transactions_bulk()` for parallel batch updates, `search_transactions`, result-size tracking; fixes for the auth retry bug, date serialization, broken pipes, and date parsing. Note: `get_account_holdings` now requires an `account_id` (the underlying library always did).
+**Current Status** (Updated August 2026): Production-ready with 227 passing tests, 25 intelligent tools (including transaction splitting via `get_transaction_splits` / `update_transaction_splits`), comprehensive analytics, robust error handling, and enhanced reliability. Recent: interactive authentication (`monarch_login`, `monarch_login_with_cookies`, `monarch_logout`, `check_auth_status` tools plus `scripts/login_setup.py`) and keyring-first session storage, added so a Cloudflare CAPTCHA gate or an MFA/emailed one-time code doesn't strand headless env-var login — see "Secure Authentication & Session Management" above. Earlier MCP modernization: every tool returns structured output (outputSchema + structured content with a text fallback), tools/resources/prompts carry human-friendly `title`s, parameterized resource templates (`accounts://{account_id}/holdings|history`), argument completions for prompts/templates, and Context-based progress reporting on the batch tools. Earlier features: `update_transactions_bulk()` for parallel batch updates, `search_transactions`, result-size tracking; fixes for the auth retry bug, date serialization, broken pipes, and date parsing. Note: `get_account_holdings` now requires an `account_id` (the underlying library always did).
 
 ## Upstream Library & Fork Landscape
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Then point your client at the local copy with absolute paths (find them with `wh
 | `get_spending_summary` | Spending aggregated by category, account, or month |
 | `get_complete_financial_overview` | Combined 5-API call in parallel |
 | `analyze_spending_patterns` | Multi-month trend analysis |
+| `monarch_login` | Interactive sign-in (email/password + MFA) when env-var login can't complete |
+| `monarch_login_with_cookies` | Interactive sign-in via a pasted browser cookie, bypasses CAPTCHA |
+| `monarch_logout` | Clear the saved session |
+| `check_auth_status` | Check whether a session is active or saved |
 
 ### Transaction format
 
@@ -224,11 +228,20 @@ By default, transactions return a compact format with the fields that matter:
 
 ## Session management
 
-Sessions are cached in `~/.monarch-mcp/` for faster subsequent logins (override the location with the `MONARCH_SESSION_DIR` env var). If you hit auth issues:
+Sessions are cached for faster subsequent logins — in your OS keychain when one is available (macOS Keychain, Windows Credential Manager, or a Linux Secret Service like GNOME Keyring/KWallet), falling back automatically to a permissioned file under `~/.monarch-mcp/` when there's no keyring backend (e.g. a headless server or container). Override the fallback location with the `MONARCH_SESSION_DIR` env var. If you hit auth issues:
 
-- Delete `~/.monarch-mcp/session.pickle` to clear the cached session
+- Call the `monarch_logout` tool, or delete `~/.monarch-mcp/session.pickle`, to clear the cached session
 - Set `MONARCH_FORCE_LOGIN=true` in your env config to force a fresh login
 - Make sure your system clock is accurate (required for TOTP)
+
+### Interactive login (CAPTCHA / MFA / email codes)
+
+The env-var login above is non-interactive, so it can't complete if Monarch responds with a Cloudflare CAPTCHA challenge, or an emailed one-time code (which can happen even with MFA disabled, for a new device/session). If that happens, authenticate once through one of these instead — the session is then saved and reused just like the env-var path:
+
+- **From your MCP client**: call the `monarch_login` tool (email/password, with an MFA/emailed-code follow-up if needed), or `monarch_login_with_cookies` if you're being CAPTCHA-blocked (paste the `cookie` request header from a logged-in browser session — DevTools → Network → any `api.monarch.com` request).
+- **From a terminal**, if you've cloned the repo: `uv run scripts/login_setup.py` — offers browser-cookie, email/password, and session-token paste options.
+
+Use `check_auth_status` to see whether a session is currently active.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Topic :: Office/Business :: Financial",
 ]
 dependencies = [
+    "keyring>=24.0.0",
     "mcp[cli]>=1.28.0,<2",
     "monarchmoneycommunity>=1.4.0",
     "pydantic>=2.12.5",

--- a/scripts/login_setup.py
+++ b/scripts/login_setup.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Standalone script for one-time interactive Monarch Money login.
+
+Run with: uv run scripts/login_setup.py
+
+Use this from a terminal — not through an MCP client — when the server's
+non-interactive MONARCH_EMAIL/MONARCH_PASSWORD login can't complete: Monarch's
+login can sit behind a Cloudflare CAPTCHA, or require an MFA code or an
+emailed one-time code. This establishes a session once and saves it via the
+same secure storage (OS keyring, falling back to a permissioned file under
+~/.monarch-mcp) that every MCP tool call reuses afterward.
+
+Supports three auth paths, in order of recommendation:
+
+1. Session cookies pasted from a logged-in browser. Sidesteps the Cloudflare
+   CAPTCHA gate entirely and works for SSO accounts that can't use password
+   login at all.
+2. Email and password, with an MFA/emailed-code prompt if Monarch asks for one.
+3. A session token pasted directly, for users who already have one.
+"""
+
+import asyncio
+import getpass
+import sys
+from pathlib import Path
+
+# Add parent to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from monarchmoney import CaptchaRequiredException, MonarchMoney, RequireMFAException  # noqa: E402
+
+from server import save_session_secure, suppressed_output  # noqa: E402
+
+
+async def _login_with_cookies() -> MonarchMoney | None:
+    print("\n📋 To copy the right cookie string:")
+    print("  1. Log in to https://app.monarch.com in Chrome or Firefox")
+    print("  2. Open DevTools (F12) → Network tab")
+    print("  3. Click any request to api.monarch.com (e.g. any 'graphql' request)")
+    print("  4. Scroll to 'Request Headers' and find the 'cookie:' header")
+    print("  5. Copy the full value (a long string of key=value; pairs)")
+    print()
+    cookie_string = getpass.getpass("Paste the Cookie header value: ").strip()
+    if not cookie_string:
+        print("❌ No cookie string provided. Exiting.")
+        return None
+
+    client = MonarchMoney()
+    try:
+        with suppressed_output():
+            await client.login_with_cookies(cookie_string, save_session=False, verify=True)
+        print("✅ Cookie login successful")
+        return client
+    except Exception as e:
+        print(f"❌ Cookie login failed: {type(e).__name__}: {e}")
+        return None
+
+
+async def _login_with_password() -> MonarchMoney | None:
+    email = input("Email: ").strip()
+    password = getpass.getpass("Password: ")
+
+    client = MonarchMoney()
+    try:
+        with suppressed_output():
+            await client.login(email, password, use_saved_session=False, save_session=False)
+        print("✅ Login successful")
+        return client
+    except CaptchaRequiredException as e:
+        print(f"❌ {e}")
+        print("Re-run this script and choose option 1 (session cookies) instead.")
+        return None
+    except RequireMFAException:
+        code = input("MFA code (or the verification code Monarch emailed you): ").strip()
+        if not code:
+            print("❌ No code provided. Exiting.")
+            return None
+        try:
+            with suppressed_output():
+                await client.multi_factor_authenticate(email, password, code)
+            print("✅ MFA/verification successful")
+            return client
+        except CaptchaRequiredException as e:
+            print(f"❌ {e}")
+            print("Re-run this script and choose option 1 (session cookies) instead.")
+            return None
+        except Exception as e:
+            print(f"❌ Login failed: {type(e).__name__}: {e}")
+            return None
+    except Exception as e:
+        print(f"❌ Login failed: {type(e).__name__}: {e}")
+        return None
+
+
+def _login_with_token() -> MonarchMoney | None:
+    print("\n📋 To get a session token:")
+    print("  1. Log in to https://app.monarch.com in Chrome or Firefox")
+    print("  2. DevTools (F12) → Application tab → Local Storage → https://app.monarch.com → key 'token'")
+    print("  3. Copy the value")
+    print()
+    token = getpass.getpass("Paste your session token: ").strip()
+    if not token:
+        print("❌ No token provided. Exiting.")
+        return None
+    return MonarchMoney(token=token)
+
+
+async def main() -> None:
+    print("\n🏦 Monarch Money — Interactive Login Setup")
+    print("=" * 45)
+    print("This authenticates you once and saves a session that every")
+    print("MCP tool call will reuse — no more re-entering credentials.\n")
+
+    print("How do you sign in to Monarch Money?")
+    print("  1) Session cookies from browser   (recommended: sidesteps CAPTCHA, supports SSO)")
+    print("  2) Email and password")
+    print("  3) Paste a session token directly")
+    choice = input("Choice [1]: ").strip() or "1"
+
+    client: MonarchMoney | None
+    if choice == "1":
+        client = await _login_with_cookies()
+    elif choice == "2":
+        client = await _login_with_password()
+    elif choice == "3":
+        client = _login_with_token()
+    else:
+        print(f"❌ Unrecognized choice: {choice!r}. Exiting.")
+        return
+
+    if client is None:
+        return
+
+    print("\nTesting connection...")
+    try:
+        with suppressed_output():
+            accounts = await client.get_accounts()
+        account_count = len(accounts.get("accounts", [])) if isinstance(accounts, dict) else 0
+        print(f"✅ Found {account_count} accounts")
+    except Exception as e:
+        print(f"❌ Connection test failed: {type(e).__name__}: {e}")
+        print("If this looks like 401 Unauthorized, the cookie/token is invalid — re-run this script.")
+        return
+
+    try:
+        save_session_secure(client)
+        print("\n✅ Session saved securely for future tool calls.")
+    except Exception as e:
+        print(f"❌ Could not save session: {type(e).__name__}: {e}")
+        return
+
+    print("\n🎉 Setup complete. Restart your MCP client to pick up the session.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 """MonarchMoney MCP Server - Provides access to Monarch Money financial data via MCP protocol."""
 
 import asyncio
+import base64
 import contextlib
 import functools
 import io
@@ -11,10 +12,11 @@ import os
 import re
 import signal
 import sys
+import tempfile
 import time
 import uuid
 import warnings
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
 from datetime import date, datetime, timedelta
 from enum import Enum
 from pathlib import Path
@@ -32,8 +34,8 @@ from mcp.types import (
     ResourceTemplateReference,
     ToolAnnotations,
 )
-from monarchmoney import MonarchMoney, RequireMFAException
-from pydantic import BaseModel, ConfigDict, JsonValue
+from monarchmoney import CaptchaRequiredException, LoginFailedException, MonarchMoney, RequireMFAException
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 # Type definitions for Monarch Money API responses
 JsonSerializable = str | int | float | bool | None | list["JsonSerializable"] | dict[str, "JsonSerializable"]
@@ -700,6 +702,37 @@ class SpendingPatterns(MMModel):
     metadata: JsonValue = None
 
 
+class AuthResult(BaseModel):
+    """Outcome of an interactive authentication action."""
+
+    success: bool
+    message: str
+
+
+# Elicitation schemas for interactive login (MCP forms). Field descriptions
+# become the labels/help text the client renders, so credentials flow
+# client-UI -> server directly over the protocol and never appear in tool
+# arguments or this conversation.
+
+
+class LoginForm(BaseModel):
+    email: str = Field(description="Monarch Money email address")
+    password: str = Field(description="Monarch Money password")
+
+
+class MFACodeForm(BaseModel):
+    code: str = Field(description="Monarch Money MFA code, or the verification code Monarch emailed you")
+
+
+class CookieForm(BaseModel):
+    cookie_header: str = Field(
+        description=(
+            "Cookie header value copied from a logged-in browser session at app.monarch.com "
+            "(DevTools → Network → any api.monarch.com request → Request Headers → 'cookie')"
+        )
+    )
+
+
 # =============================================================================
 # MCP Resources - Read-only data endpoints for reference data
 # =============================================================================
@@ -958,6 +991,153 @@ session_dir = Path(_session_dir_env).expanduser() if _session_dir_env else Path.
 session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 session_file = session_dir / "session.pickle"
 
+# Keyring-first session storage, falling back to the file above.
+#
+# Monarch's login now sits behind Cloudflare CAPTCHA and can require an
+# emailed one-time code even with MFA disabled, so a fresh non-interactive
+# login is not always possible. Once a session IS established (via env-var
+# login, the scripts/login_setup.py script, or the interactive monarch_login tools
+# below) it's reused for as long as possible rather than re-attempted, and
+# stored in the OS keychain when one is available rather than in plaintext.
+KEYRING_SERVICE = "monarch-mcp"
+KEYRING_USERNAME = "session"
+_KEYRING_PROBE_USERNAME = "__probe__"
+
+
+def _keyring_available() -> bool:
+    """Probe whether the active keyring backend can actually round-trip a value.
+
+    Headless Linux and CI containers commonly have the ``keyring`` package
+    installed but no working Secret Service / keychain daemon behind it, so
+    an import check alone isn't enough — we set + get + delete a sentinel
+    and trust the backend only if every step succeeds.
+    """
+    try:
+        import keyring
+    except ImportError:
+        return False
+
+    try:
+        keyring.set_password(KEYRING_SERVICE, _KEYRING_PROBE_USERNAME, "1")
+        stored = keyring.get_password(KEYRING_SERVICE, _KEYRING_PROBE_USERNAME)
+        keyring.delete_password(KEYRING_SERVICE, _KEYRING_PROBE_USERNAME)
+    except Exception:
+        return False
+
+    return stored == "1"
+
+
+@contextlib.contextmanager
+def suppressed_output() -> Iterator[None]:
+    """Suppress stdout/stderr around third-party calls that may print.
+
+    Any stray print to stdout corrupts the MCP JSON-RPC stdio stream, so
+    every call into the monarchmoney library that touches disk or network
+    I/O is wrapped with this.
+    """
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        yield
+
+
+def _session_bytes_from_client(client: MonarchMoney) -> bytes:
+    """Serialize a client's session via its own save_session(), off a scratch file."""
+    fd, tmp_path = tempfile.mkstemp(prefix="session-", dir=str(session_dir))
+    os.close(fd)
+    try:
+        with suppressed_output():
+            client.save_session(tmp_path)
+        return Path(tmp_path).read_bytes()
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def _client_from_session_bytes(blob: bytes) -> MonarchMoney:
+    """Reconstruct a client from bytes produced by _session_bytes_from_client()."""
+    fd, tmp_path = tempfile.mkstemp(prefix="session-", dir=str(session_dir))
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(blob)
+        client = MonarchMoney()
+        with suppressed_output():
+            client.load_session(tmp_path)
+        return client
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def has_saved_session() -> bool:
+    """Check whether a session is saved, without materializing a client."""
+    if _keyring_available():
+        try:
+            import keyring
+
+            if keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME) is not None:
+                return True
+        except Exception:
+            pass
+    return session_file.exists()
+
+
+def save_session_secure(client: MonarchMoney) -> None:
+    """Persist an authenticated session, preferring the OS keyring over disk."""
+    blob = _session_bytes_from_client(client)
+
+    if _keyring_available():
+        try:
+            import keyring
+
+            keyring.set_password(KEYRING_SERVICE, KEYRING_USERNAME, base64.b64encode(blob).decode())
+            # Avoid leaving a stale plaintext copy around once the keyring has it.
+            session_file.unlink(missing_ok=True)
+            log.info("auth_session_saved", backend="keyring")
+            return
+        except Exception as e:
+            log.warning("auth_keyring_save_failed", error=str(e))
+
+    session_file.write_bytes(blob)
+    session_file.chmod(0o600)
+    log.info("auth_session_saved", backend="file")
+
+
+def load_session_secure() -> MonarchMoney | None:
+    """Load a previously saved session, preferring the OS keyring over disk."""
+    if _keyring_available():
+        try:
+            import keyring
+
+            raw = keyring.get_password(KEYRING_SERVICE, KEYRING_USERNAME)
+            if raw:
+                return _client_from_session_bytes(base64.b64decode(raw))
+        except Exception as e:
+            log.warning("auth_keyring_load_failed", error=str(e))
+
+    if session_file.exists():
+        try:
+            return _client_from_session_bytes(session_file.read_bytes())
+        except Exception as e:
+            log.warning("auth_session_load_failed", error=str(e))
+
+    return None
+
+
+def clear_session_secure(reason: str = "unknown") -> None:
+    """Remove any saved session from both the keyring and disk."""
+    if _keyring_available():
+        try:
+            import keyring
+
+            keyring.delete_password(KEYRING_SERVICE, KEYRING_USERNAME)
+        except Exception as e:
+            log.warning("auth_keyring_clear_failed", error=str(e))
+
+    for path in [session_file, session_dir / "mm_session.pickle"]:
+        if path.exists():
+            try:
+                path.unlink()
+                log.info("session_file_cleared", path=str(path), reason=reason)
+            except Exception as e:
+                log.warning("session_file_clear_failed", path=str(path), error=str(e))
+
 
 def is_auth_error(error: Exception) -> bool:
     """Determine if an error is a genuine authentication/authorization failure.
@@ -1003,10 +1183,10 @@ def is_auth_error(error: Exception) -> bool:
 
 
 def clear_session(reason: str = "unknown") -> None:
-    """Clear session files and reset authentication state to allow fresh re-authentication.
+    """Clear the saved session and reset authentication state to allow fresh re-authentication.
 
     This function performs a complete authentication reset:
-    - Clears session files from disk (.mm/session.pickle, .mm/mm_session.pickle)
+    - Clears the saved session from the keyring and disk (see clear_session_secure())
     - Resets the client instance (mm_client = None)
     - Resets auth state to NOT_INITIALIZED
     - Clears auth errors and failure timestamps
@@ -1020,21 +1200,12 @@ def clear_session(reason: str = "unknown") -> None:
 
     log.info("auth_reset", reason=reason, previous_state=auth_state.value)
 
-    if mm_client is not None:
-        mm_client = None
-
+    mm_client = None
     auth_state = AuthState.NOT_INITIALIZED
     auth_error = None
     auth_failed_at = None
 
-    # Clear session files
-    for path in [session_file, session_dir / "mm_session.pickle"]:
-        if path.exists():
-            try:
-                path.unlink()
-                log.info("session_file_cleared", path=str(path))
-            except Exception as e:
-                log.warning("session_file_clear_failed", path=str(path), error=str(e))
+    clear_session_secure(reason=reason)
 
 
 async def api_call_with_retry(method_name: str, *args: Any, max_retries: int = 3, **kwargs: Any) -> Any:
@@ -1115,18 +1286,42 @@ async def api_call_with_retry(method_name: str, *args: Any, max_retries: int = 3
 async def initialize_client() -> None:
     """Initialize the MonarchMoney client with authentication.
 
-    This function attempts to use cached sessions when possible and only
-    performs fresh authentication when necessary. It does NOT validate
-    sessions immediately - validation happens on first API call.
+    Prefers a previously saved session (OS keyring, falling back to a
+    permissioned file) over a fresh password login: Monarch's login can sit
+    behind a Cloudflare CAPTCHA or require an emailed one-time code even
+    with MFA disabled, neither of which a headless retry can satisfy, so an
+    already-established session is reused for as long as possible rather
+    than re-attempted. Falls back to MONARCH_EMAIL/MONARCH_PASSWORD (and
+    optionally MONARCH_MFA_SECRET for TOTP) for a fresh non-interactive
+    login when no saved session exists. When that's blocked by CAPTCHA or a
+    non-TOTP MFA challenge, use `scripts/login_setup.py` or the `monarch_login` /
+    `monarch_login_with_cookies` MCP tools instead.
     """
     global mm_client, auth_state, auth_error, auth_failed_at
+
+    force_login = os.getenv("MONARCH_FORCE_LOGIN") == "true"
+    if force_login:
+        log.info("auth_force_login")
+        clear_session_secure(reason="forced login requested")
+    else:
+        saved_client = load_session_secure()
+        if saved_client is not None:
+            mm_client = saved_client
+            auth_state = AuthState.AUTHENTICATED
+            auth_error = None
+            log.info("auth_session_loaded")
+            return
 
     email = os.getenv("MONARCH_EMAIL")
     password = os.getenv("MONARCH_PASSWORD")
     mfa_secret = os.getenv("MONARCH_MFA_SECRET")
 
     if not email or not password:
-        error_msg = "MONARCH_EMAIL and MONARCH_PASSWORD environment variables are required"
+        error_msg = (
+            "No saved Monarch Money session found, and MONARCH_EMAIL/MONARCH_PASSWORD "
+            "are not set. Run `uv run scripts/login_setup.py` from the repo, or call the "
+            "`monarch_login` MCP tool to sign in interactively."
+        )
         log.error("auth_missing_credentials")
         auth_state = AuthState.FAILED
         auth_error = error_msg
@@ -1135,29 +1330,6 @@ async def initialize_client() -> None:
     log.info("auth_init", email=email)
     mm_client = MonarchMoney()
 
-    # Try to load existing session first (unless forced to skip)
-    force_login = os.getenv("MONARCH_FORCE_LOGIN") == "true"
-    if session_file.exists() and not force_login:
-        try:
-            stdout_capture = io.StringIO()
-            stderr_capture = io.StringIO()
-            with contextlib.redirect_stdout(stdout_capture), contextlib.redirect_stderr(stderr_capture):
-                mm_client.load_session(str(session_file))
-
-            log.info("auth_session_loaded", session_file=str(session_file))
-            auth_state = AuthState.AUTHENTICATED
-            return
-
-        except Exception as e:
-            log.warning("auth_session_load_failed", error=str(e))
-            if is_auth_error(e):
-                clear_session(reason="invalid session file")
-
-    else:
-        if force_login:
-            log.info("auth_force_login")
-            clear_session(reason="forced login requested")
-
     # Perform fresh authentication
     max_retries = 2
     retry_delay = 3
@@ -1165,27 +1337,41 @@ async def initialize_client() -> None:
     for attempt in range(max_retries):
         try:
             log.info("auth_login_attempt", attempt=attempt + 1, max_retries=max_retries, mfa=bool(mfa_secret))
-            if mfa_secret:
-                await mm_client.login(email, password, mfa_secret_key=mfa_secret, use_saved_session=False)
-            else:
-                await mm_client.login(email, password, use_saved_session=False)
+            with suppressed_output():
+                if mfa_secret:
+                    await mm_client.login(
+                        email, password, mfa_secret_key=mfa_secret, use_saved_session=False, save_session=False
+                    )
+                else:
+                    await mm_client.login(email, password, use_saved_session=False, save_session=False)
 
-            # Save session with stdout/stderr suppression
-            stdout_capture = io.StringIO()
-            stderr_capture = io.StringIO()
-            with contextlib.redirect_stdout(stdout_capture), contextlib.redirect_stderr(stderr_capture):
-                mm_client.save_session(str(session_file))
-
-            if session_file.exists():
-                session_file.chmod(0o600)
+            save_session_secure(mm_client)
 
             auth_state = AuthState.AUTHENTICATED
             auth_error = None
             log.info("auth_success")
             return
 
+        except CaptchaRequiredException as e:
+            error_msg = (
+                "Monarch blocked this login attempt with a CAPTCHA challenge, which can't "
+                "be solved headlessly. Run `uv run scripts/login_setup.py` from the repo and choose "
+                "the browser-cookie option, or call the `monarch_login_with_cookies` MCP "
+                "tool to paste a Cookie header from a logged-in browser session."
+            )
+            log.error("auth_captcha_required")
+            auth_state = AuthState.FAILED
+            auth_error = error_msg
+            auth_failed_at = time.time()
+            raise ValueError(error_msg) from e
+
         except RequireMFAException as e:
-            error_msg = "Multi-factor authentication required but MONARCH_MFA_SECRET not set"
+            error_msg = (
+                "Multi-factor authentication (or an emailed verification code) is required "
+                "but MONARCH_MFA_SECRET is not set — and an emailed code can't be satisfied "
+                "by a TOTP secret anyway. Run `uv run scripts/login_setup.py` from the repo, or call "
+                "the `monarch_login` MCP tool to complete it interactively."
+            )
             log.error("auth_mfa_required")
             auth_state = AuthState.FAILED
             auth_error = error_msg
@@ -2522,6 +2708,151 @@ async def analyze_spending_patterns(
     except Exception as e:
         log.error("Failed to analyze spending patterns", error=str(e), lookback_months=lookback_months)
         raise
+
+
+# =============================================================================
+# Authentication tools
+#
+# Establish or clear a session interactively, for when MONARCH_EMAIL /
+# MONARCH_PASSWORD login (in initialize_client()) can't complete headlessly —
+# e.g. Monarch's Cloudflare CAPTCHA gate, or an MFA/emailed verification code
+# with no MONARCH_MFA_SECRET configured. A session established this way is
+# saved via save_session_secure() and reused by every other tool exactly
+# like one from the env-var login path.
+# =============================================================================
+
+
+async def _activate_session(client: MonarchMoney) -> None:
+    """Save a freshly authenticated client and make it the active session."""
+    global mm_client, auth_state, auth_lock, auth_error, auth_failed_at
+
+    save_session_secure(client)
+
+    if auth_lock is None:
+        auth_lock = asyncio.Lock()
+    async with auth_lock:
+        mm_client = client
+        auth_state = AuthState.AUTHENTICATED
+        auth_error = None
+        auth_failed_at = None
+
+
+@mcp.tool(annotations=WRITE_SIDE_EFFECT, title="Sign In To Monarch Money")
+async def monarch_login(ctx: Context) -> AuthResult:
+    """Sign in to Monarch Money interactively.
+
+    Opens a form in the client UI to collect email and password, followed by
+    an MFA/emailed-code form if Monarch requires one. Credentials flow
+    client-UI → server directly over the MCP protocol and never appear in
+    tool arguments or this conversation. Use this when the env-var login
+    fails with an MFA or emailed-verification-code error; if it fails with a
+    CAPTCHA error, use `monarch_login_with_cookies` instead.
+    """
+    if not hasattr(ctx, "elicit"):
+        return AuthResult(
+            success=False,
+            message="Interactive login requires MCP elicitation support (mcp>=1.10.0) in your client.",
+        )
+
+    form = await ctx.elicit(message="Sign in to Monarch Money.", schema=LoginForm)
+    if form.action != "accept" or form.data is None:
+        return AuthResult(success=False, message="Login cancelled.")
+
+    client = MonarchMoney()
+    try:
+        with suppressed_output():
+            await client.login(form.data.email, form.data.password, use_saved_session=False, save_session=False)
+    except RequireMFAException:
+        mfa = await ctx.elicit(
+            message="Enter your Monarch Money MFA code, or the verification code Monarch emailed you.",
+            schema=MFACodeForm,
+        )
+        if mfa.action != "accept" or mfa.data is None:
+            return AuthResult(success=False, message="Login cancelled.")
+        try:
+            with suppressed_output():
+                await client.multi_factor_authenticate(form.data.email, form.data.password, mfa.data.code)
+        except CaptchaRequiredException:
+            return AuthResult(
+                success=False,
+                message="Monarch blocked this login with a CAPTCHA challenge. Use `monarch_login_with_cookies` instead.",
+            )
+        except (LoginFailedException, RequireMFAException) as e:
+            return AuthResult(success=False, message=f"Login failed: {e}")
+    except CaptchaRequiredException:
+        return AuthResult(
+            success=False,
+            message="Monarch blocked this login with a CAPTCHA challenge. Use `monarch_login_with_cookies` instead.",
+        )
+    except LoginFailedException as e:
+        return AuthResult(success=False, message=f"Login failed: {e}")
+
+    await _activate_session(client)
+    log.info("auth_success", method="interactive")
+    return AuthResult(success=True, message="Signed in. Session saved securely for future tool calls.")
+
+
+@mcp.tool(annotations=WRITE_SIDE_EFFECT, title="Sign In With Browser Cookies")
+async def monarch_login_with_cookies(ctx: Context) -> AuthResult:
+    """Sign in to Monarch Money using cookies copied from a logged-in browser.
+
+    Bypasses the Cloudflare CAPTCHA gate that can block programmatic login
+    entirely, and works for SSO accounts that can't use password login.
+    Grab the 'cookie' request header from DevTools → Network on any
+    api.monarch.com request while logged in at app.monarch.com.
+    """
+    if not hasattr(ctx, "elicit"):
+        return AuthResult(
+            success=False,
+            message="Interactive login requires MCP elicitation support (mcp>=1.10.0) in your client.",
+        )
+
+    form = await ctx.elicit(message="Paste your Monarch Money browser Cookie header.", schema=CookieForm)
+    if form.action != "accept" or form.data is None:
+        return AuthResult(success=False, message="Login cancelled.")
+
+    cookie_header = form.data.cookie_header.strip()
+    if not cookie_header:
+        return AuthResult(success=False, message="Empty cookie value — aborting.")
+
+    client = MonarchMoney()
+    try:
+        with suppressed_output():
+            await client.login_with_cookies(cookie_header, save_session=False, verify=True)
+    except LoginFailedException as e:
+        return AuthResult(success=False, message=f"Cookie login failed: {e}")
+
+    await _activate_session(client)
+    log.info("auth_success", method="cookies")
+    return AuthResult(
+        success=True, message="Signed in with browser cookies. Session saved securely for future tool calls."
+    )
+
+
+@mcp.tool(annotations=WRITE_SIDE_EFFECT, title="Sign Out Of Monarch Money")
+async def monarch_logout() -> AuthResult:
+    """Clear the saved Monarch Money session (both keyring and on-disk fallback)."""
+    clear_session(reason="user requested logout")
+    return AuthResult(success=True, message="Signed out. Saved session cleared.")
+
+
+@mcp.tool(annotations=READONLY, title="Check Authentication Status")
+async def check_auth_status() -> AuthResult:
+    """Report whether a Monarch Money session is currently active or saved."""
+    if auth_state == AuthState.AUTHENTICATED and mm_client is not None:
+        return AuthResult(success=True, message="Authenticated for this session.")
+    if has_saved_session():
+        return AuthResult(
+            success=True,
+            message="A saved session exists and will be used automatically on the next tool call.",
+        )
+    return AuthResult(
+        success=False,
+        message=(
+            "Not authenticated. Call `monarch_login` (or `monarch_login_with_cookies` if you're "
+            "being CAPTCHA-blocked), or run `uv run scripts/login_setup.py` from the repo."
+        ),
+    )
 
 
 async def main() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,26 @@
 """Shared pytest fixtures for the test suite."""
 
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
 import server
+
+
+@pytest.fixture(autouse=True)
+def _isolated_session_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point session storage at a scratch dir so tests never touch a real ~/.monarch-mcp.
+
+    Without this, any test that exercises initialize_client()/save_session_secure()
+    without explicitly mocking server.session_file would read or write the real,
+    developer-machine session file.
+    """
+    session_dir = tmp_path / ".monarch-mcp"
+    session_dir.mkdir(mode=0o700)
+    monkeypatch.setattr(server, "session_dir", session_dir)
+    monkeypatch.setattr(server, "session_file", session_dir / "session.pickle")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_auth_retry.py
+++ b/tests/test_auth_retry.py
@@ -143,41 +143,61 @@ class TestAuthenticationRetry:
             assert not mock_auth.called
 
     @pytest.mark.asyncio
-    async def test_initialize_client_loads_session_without_validation(self):
-        """Test that initialize_client loads existing sessions without validating them."""
+    async def test_initialize_client_loads_saved_session_without_login(self):
+        """Test that initialize_client reuses a saved session instead of logging in fresh.
+
+        The saved session may come from a plain env-var login, login_setup.py, or one
+        of the interactive monarch_login tools — initialize_client() doesn't care which;
+        it just prefers load_session_secure() over a fresh password login, since Monarch's
+        CAPTCHA/MFA/email-OTP gates can't always be satisfied headlessly.
+        """
+        import server
+
+        original_auth_state = server.auth_state
+        server.auth_state = server.AuthState.NOT_INITIALIZED
+
+        saved_client = MagicMock()
+
+        try:
+            with (
+                patch("server.load_session_secure", return_value=saved_client),
+                patch("server.MonarchMoney") as mock_mm_class,
+            ):
+                await server.initialize_client()
+
+                # The saved client became the active session...
+                assert server.mm_client is saved_client
+                assert server.auth_state == server.AuthState.AUTHENTICATED
+                # ...and no fresh client/login was attempted.
+                assert not mock_mm_class.called
+        finally:
+            server.auth_state = original_auth_state
+
+    @pytest.mark.asyncio
+    async def test_initialize_client_falls_back_to_login_when_no_saved_session(self):
+        """Test that initialize_client logs in fresh when no saved session exists."""
         import os
 
         import server
 
-        # Reset auth state before test
         original_auth_state = server.auth_state
         server.auth_state = server.AuthState.NOT_INITIALIZED
 
         try:
-            # Mock environment variables
             with (
                 patch.dict(os.environ, {"MONARCH_EMAIL": "test@example.com", "MONARCH_PASSWORD": "testpass"}),
-                patch("server.session_file") as mock_session_file,
+                patch("server.load_session_secure", return_value=None),
+                patch("server.save_session_secure"),
                 patch("server.MonarchMoney") as mock_mm_class,
             ):
-                # Setup: session file exists
-                mock_session_file.exists.return_value = True
-
-                # Mock the client
                 mock_client = AsyncMock()
                 mock_mm_class.return_value = mock_client
 
-                # Call initialize_client
                 await server.initialize_client()
 
-                # Verify that session was loaded (load_session called)
-                assert mock_client.load_session.called
-                # Verify that login was NOT called (we loaded existing session)
-                assert not mock_client.login.called
-                # Verify auth state is AUTHENTICATED after loading session
+                assert mock_client.login.called
                 assert server.auth_state == server.AuthState.AUTHENTICATED
         finally:
-            # Restore original state
             server.auth_state = original_auth_state
 
     def test_clear_session_removes_both_session_files(self):
@@ -198,6 +218,25 @@ class TestAuthenticationRetry:
 
             # Verify both files were attempted to be removed
             assert mock_custom_session.unlink.called
+
+    def test_clear_session_secure_clears_keyring_when_available(self):
+        """Test that clear_session_secure deletes the keyring entry when a backend is present."""
+        from server import clear_session_secure
+
+        with (
+            patch("server._keyring_available", return_value=True),
+            patch("server.session_file") as mock_session_file,
+            patch("server.session_dir") as mock_session_dir,
+        ):
+            mock_session_file.exists.return_value = False
+            mock_session_dir.__truediv__ = MagicMock(return_value=MagicMock(exists=MagicMock(return_value=False)))
+
+            with patch.dict("sys.modules", {"keyring": MagicMock()}):
+                import keyring
+
+                clear_session_secure(reason="test")
+
+                assert keyring.delete_password.called
 
     @pytest.mark.asyncio
     async def test_auth_error_indicators_comprehensive(self):

--- a/tests/test_auth_tools.py
+++ b/tests/test_auth_tools.py
@@ -1,0 +1,263 @@
+"""Tests for the interactive authentication tools and secure session storage.
+
+monarch_login / monarch_login_with_cookies / monarch_logout / check_auth_status
+are the escape hatch for when the env-var (MONARCH_EMAIL/MONARCH_PASSWORD) login
+in initialize_client() can't complete headlessly — a Cloudflare CAPTCHA gate, or
+an MFA/emailed one-time code with no MONARCH_MFA_SECRET configured.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from monarchmoney import CaptchaRequiredException, LoginFailedException, RequireMFAException
+
+import server
+
+
+class NoElicitContext:
+    """Stands in for a client that doesn't support MCP elicitation."""
+
+
+def elicit_result(action: str, data: object | None = None) -> SimpleNamespace:
+    return SimpleNamespace(action=action, data=data)
+
+
+class TestMonarchLogin:
+    @pytest.mark.asyncio
+    async def test_no_elicit_support(self) -> None:
+        result = await server.monarch_login(NoElicitContext())  # type: ignore[arg-type]
+        assert result.success is False
+        assert "elicitation" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_login_cancelled(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(return_value=elicit_result("decline"))
+        result = await server.monarch_login(ctx)
+        assert result.success is False
+        assert "cancelled" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_login_succeeds_without_mfa(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            return_value=elicit_result("accept", server.LoginForm(email="user@example.com", password="hunter2"))
+        )
+
+        original_client, original_state = server.mm_client, server.auth_state
+        try:
+            with (
+                patch("server.MonarchMoney") as mock_mm_class,
+                patch("server.save_session_secure") as mock_save,
+            ):
+                mock_client = AsyncMock()
+                mock_mm_class.return_value = mock_client
+
+                result = await server.monarch_login(ctx)
+
+            assert result.success is True
+            assert mock_client.login.called
+            assert mock_save.called
+            assert server.mm_client is mock_client
+            assert server.auth_state == server.AuthState.AUTHENTICATED
+        finally:
+            server.mm_client, server.auth_state = original_client, original_state
+
+    @pytest.mark.asyncio
+    async def test_login_completes_mfa_challenge(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            side_effect=[
+                elicit_result("accept", server.LoginForm(email="user@example.com", password="hunter2")),
+                elicit_result("accept", server.MFACodeForm(code="123456")),
+            ]
+        )
+
+        original_client, original_state = server.mm_client, server.auth_state
+        try:
+            with (
+                patch("server.MonarchMoney") as mock_mm_class,
+                patch("server.save_session_secure"),
+            ):
+                mock_client = AsyncMock()
+                mock_client.login.side_effect = RequireMFAException("MFA required")
+                mock_mm_class.return_value = mock_client
+
+                result = await server.monarch_login(ctx)
+
+            assert result.success is True
+            mock_client.multi_factor_authenticate.assert_called_once_with("user@example.com", "hunter2", "123456")
+        finally:
+            server.mm_client, server.auth_state = original_client, original_state
+
+    @pytest.mark.asyncio
+    async def test_login_blocked_by_captcha(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            return_value=elicit_result("accept", server.LoginForm(email="user@example.com", password="hunter2"))
+        )
+
+        with patch("server.MonarchMoney") as mock_mm_class:
+            mock_client = AsyncMock()
+            mock_client.login.side_effect = CaptchaRequiredException("blocked")
+            mock_mm_class.return_value = mock_client
+
+            result = await server.monarch_login(ctx)
+
+        assert result.success is False
+        assert "monarch_login_with_cookies" in result.message
+
+    @pytest.mark.asyncio
+    async def test_login_failed_credentials(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            return_value=elicit_result("accept", server.LoginForm(email="user@example.com", password="wrong"))
+        )
+
+        with patch("server.MonarchMoney") as mock_mm_class:
+            mock_client = AsyncMock()
+            mock_client.login.side_effect = LoginFailedException("bad credentials")
+            mock_mm_class.return_value = mock_client
+
+            result = await server.monarch_login(ctx)
+
+        assert result.success is False
+        assert "bad credentials" in result.message
+
+
+class TestMonarchLoginWithCookies:
+    @pytest.mark.asyncio
+    async def test_no_elicit_support(self) -> None:
+        result = await server.monarch_login_with_cookies(NoElicitContext())  # type: ignore[arg-type]
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_empty_cookie_value(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(return_value=elicit_result("accept", server.CookieForm(cookie_header="   ")))
+        result = await server.monarch_login_with_cookies(ctx)
+        assert result.success is False
+        assert "empty" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_cookie_login_succeeds(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            return_value=elicit_result("accept", server.CookieForm(cookie_header="session_id=abc; csrftoken=def"))
+        )
+
+        original_client, original_state = server.mm_client, server.auth_state
+        try:
+            with (
+                patch("server.MonarchMoney") as mock_mm_class,
+                patch("server.save_session_secure") as mock_save,
+            ):
+                mock_client = AsyncMock()
+                mock_mm_class.return_value = mock_client
+
+                result = await server.monarch_login_with_cookies(ctx)
+
+            assert result.success is True
+            assert mock_client.login_with_cookies.called
+            assert mock_save.called
+        finally:
+            server.mm_client, server.auth_state = original_client, original_state
+
+    @pytest.mark.asyncio
+    async def test_cookie_login_fails(self) -> None:
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            return_value=elicit_result("accept", server.CookieForm(cookie_header="not_a_real_cookie"))
+        )
+
+        with patch("server.MonarchMoney") as mock_mm_class:
+            mock_client = AsyncMock()
+            mock_client.login_with_cookies.side_effect = LoginFailedException("missing required cookies")
+            mock_mm_class.return_value = mock_client
+
+            result = await server.monarch_login_with_cookies(ctx)
+
+        assert result.success is False
+        assert "missing required cookies" in result.message
+
+
+class TestMonarchLogoutAndStatus:
+    @pytest.mark.asyncio
+    async def test_logout_clears_session(self) -> None:
+        with patch("server.clear_session") as mock_clear:
+            result = await server.monarch_logout()
+        assert result.success is True
+        assert mock_clear.called
+
+    @pytest.mark.asyncio
+    async def test_check_auth_status_when_authenticated(self) -> None:
+        # The autouse baseline fixture already authenticates mm_client.
+        result = await server.check_auth_status()
+        assert result.success is True
+        assert "authenticated" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_check_auth_status_with_saved_session(self) -> None:
+        original_client, original_state = server.mm_client, server.auth_state
+        try:
+            server.mm_client = None
+            server.auth_state = server.AuthState.NOT_INITIALIZED
+            with patch("server.has_saved_session", return_value=True):
+                result = await server.check_auth_status()
+            assert result.success is True
+            assert "saved session" in result.message.lower()
+        finally:
+            server.mm_client, server.auth_state = original_client, original_state
+
+    @pytest.mark.asyncio
+    async def test_check_auth_status_when_not_authenticated(self) -> None:
+        original_client, original_state = server.mm_client, server.auth_state
+        try:
+            server.mm_client = None
+            server.auth_state = server.AuthState.NOT_INITIALIZED
+            with patch("server.has_saved_session", return_value=False):
+                result = await server.check_auth_status()
+            assert result.success is False
+            assert "monarch_login" in result.message
+        finally:
+            server.mm_client, server.auth_state = original_client, original_state
+
+
+class TestKeyringAvailability:
+    def test_unavailable_when_keyring_not_installed(self) -> None:
+        with patch.dict("sys.modules", {"keyring": None}):
+            assert server._keyring_available() is False
+
+    def test_unavailable_when_backend_probe_fails(self) -> None:
+        fake_keyring = MagicMock()
+        fake_keyring.set_password.side_effect = Exception("no backend")
+        with patch.dict("sys.modules", {"keyring": fake_keyring}):
+            assert server._keyring_available() is False
+
+    def test_available_when_probe_round_trips(self) -> None:
+        fake_keyring = MagicMock()
+        fake_keyring.get_password.return_value = "1"
+        with patch.dict("sys.modules", {"keyring": fake_keyring}):
+            assert server._keyring_available() is True
+
+
+class TestSecureSessionFileFallback:
+    """These exercise the file-fallback path; the sandbox test env has no real keyring backend."""
+
+    def test_save_and_load_round_trip(self) -> None:
+        client = server.MonarchMoney(token="tok_abc123")
+
+        with patch("server._keyring_available", return_value=False):
+            server.save_session_secure(client)
+            assert server.has_saved_session() is True
+
+            loaded = server.load_session_secure()
+
+        assert loaded is not None
+        assert loaded.token == "tok_abc123"
+
+    def test_load_returns_none_when_nothing_saved(self) -> None:
+        with patch("server._keyring_available", return_value=False):
+            assert server.load_session_secure() is None
+            assert server.has_saved_session() is False

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -1,6 +1,6 @@
 """Tests for FastMCP server implementation."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -36,7 +36,7 @@ class TestFastMCPServer:
     @pytest.mark.asyncio
     async def test_initialize_client_missing_credentials(self) -> None:
         """Test client initialization fails with missing credentials."""
-        with pytest.raises(ValueError, match="MONARCH_EMAIL and MONARCH_PASSWORD"):
+        with pytest.raises(ValueError, match="MONARCH_EMAIL/MONARCH_PASSWORD"):
             await server.initialize_client()
 
     @patch.dict("os.environ", {"MONARCH_EMAIL": "test@example.com", "MONARCH_PASSWORD": "testpass"})
@@ -44,8 +44,12 @@ class TestFastMCPServer:
     @pytest.mark.asyncio
     async def test_initialize_client_success(self, mock_monarch_class: AsyncMock) -> None:
         """Test successful client initialization."""
-        # Setup mock
+        # Setup mock. save_session/load_session are sync in the real client, so give
+        # them non-async mocks — AsyncMock defaults every attribute to a coroutine,
+        # which would otherwise leave save_session's return value un-awaited.
         mock_client = AsyncMock()
+        mock_client.save_session = MagicMock()
+        mock_client.load_session = MagicMock()
         mock_monarch_class.return_value = mock_client
 
         # Reset global client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,7 +72,7 @@ class TestServerInitialization:
     @pytest.mark.asyncio
     async def test_initialize_client_missing_credentials(self) -> None:
         """Test client initialization fails with missing credentials."""
-        with pytest.raises(ValueError, match="MONARCH_EMAIL and MONARCH_PASSWORD"):
+        with pytest.raises(ValueError, match="MONARCH_EMAIL/MONARCH_PASSWORD"):
             await server.initialize_client()
 
     @patch.dict("os.environ", {"MONARCH_EMAIL": "test@example.com", "MONARCH_PASSWORD": "testpass"})
@@ -80,8 +80,12 @@ class TestServerInitialization:
     @pytest.mark.asyncio
     async def test_initialize_client_success(self, mock_monarch_class: Mock) -> None:
         """Test successful client initialization."""
-        # Setup mock
+        # Setup mock. save_session/load_session are sync in the real client, so give
+        # them non-async mocks — AsyncMock defaults every attribute to a coroutine,
+        # which would otherwise leave save_session's return value un-awaited.
         mock_client = AsyncMock()
+        mock_client.save_session = Mock()
+        mock_client.load_session = Mock()
         mock_monarch_class.return_value = mock_client
 
         # Reset global client

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -21,8 +21,8 @@ def test_every_tool_advertises_output_schema() -> None:
     assert without_schema == []
 
 
-def test_tool_count_is_twenty_one() -> None:
-    assert len(mgr.list_tools()) == 21
+def test_tool_count_is_twenty_five() -> None:
+    assert len(mgr.list_tools()) == 25
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -289,6 +289,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -773,12 +782,69 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -807,6 +873,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -950,9 +1034,10 @@ wheels = [
 
 [[package]]
 name = "monarch-mcp-jamiew"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "keyring" },
     { name = "mcp", extra = ["cli"] },
     { name = "monarchmoneycommunity" },
     { name = "pydantic" },
@@ -972,6 +1057,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "keyring", specifier = ">=24.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
     { name = "monarchmoneycommunity", git = "https://github.com/bradleyseanf/monarchmoneycommunity?rev=c6904e4ec8938c7386e73ed503b7c0a0693dd6a4" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -997,6 +1083,15 @@ dependencies = [
     { name = "aiohttp" },
     { name = "gql" },
     { name = "oathtool" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1664,6 +1759,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1974,6 +2078,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2256,4 +2373,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

Monarch's login can sit behind a Cloudflare CAPTCHA or require an emailed one-time code even with MFA disabled — neither satisfiable by the existing non-interactive `MONARCH_EMAIL`/`MONARCH_PASSWORD` login. This adds the same escape hatch used in [robcerda/monarch-mcp-server](https://github.com/robcerda/monarch-mcp-server): interactive login tools, a terminal setup script, and keyring-backed session storage — layered on top of the existing env-var login rather than replacing it, since that path already works for the common TOTP-MFA case and is documented across `.mcp.json`/Docker/Smithery configs for real users.

- **`monarch_login` / `monarch_login_with_cookies`** MCP tools use `Context.elicit` so credentials flow client-UI -> server directly, never through tool arguments or the model. `monarch_logout` and `check_auth_status` round out the flow.
- **`scripts/login_setup.py`** offers the same three paths from a terminal (browser cookies, password+MFA, token paste) for users running from a repo clone.
- **Sessions now save to the OS keyring first** (probed with a set/get/delete round-trip, since headless environments often have the `keyring` package installed but no working backend), falling back to the existing permissioned file under `~/.monarch-mcp` otherwise.
- **`initialize_client()`** now prefers a saved session over a fresh login, and gives an actionable error pointing at the tools above when CAPTCHA or a non-TOTP MFA challenge blocks it, instead of a generic failure. The env-var login path itself is unchanged.

Tool count goes from 21 -> 25. `uv.lock` picks up `keyring` and its transitive deps (`jeepney`, `secretstorage`, `jaraco-*`, etc. on Linux).

This applies cleanly on top of current `main` (verified: the branch's base commit is `main`'s current HEAD).

## Test plan

- [x] `uv run python scripts/ci.py` — ruff check, ruff format, mypy (strict), pytest all green
- [x] 227 passed, 5 skipped (was 206 passed before this change; added `tests/test_auth_tools.py` plus reworked the auth-retry/session tests that assumed the old pickle-only flow)
- [x] Verified in a sandbox with no real OS keyring backend that the file-fallback path is exercised end-to-end: save -> load -> clear round-trips correctly
- [X] Manual: run `scripts/login_setup.py` against a live Monarch account hitting a CAPTCHA/MFA gate, and confirm `monarch_login`/`monarch_login_with_cookies` work from an MCP client that supports elicitation

